### PR TITLE
feat: start cross publishing the dynver package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
           cache: 'sbt'
-      - run: sbt test scripted mimaReportBinaryIssues
+      - run: sbt +test scripted mimaReportBinaryIssues

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,15 @@
 val dynverRoot = project.in(file("."))
 aggregateProjects(dynverLib, sbtdynver)
 
+lazy val scalacOptions212 = Seq(
+  "-Xlint",
+  "-Xfuture",
+  "-Ywarn-dead-code",
+  "-Ywarn-numeric-widen",
+  "-Ywarn-value-discard",
+  "-Yno-adapted-args",
+)
+
 inThisBuild(List(
   organization := "com.github.sbt",
       licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
@@ -15,14 +24,13 @@ inThisBuild(List(
 
   scalaVersion := "2.12.17",
 
-  scalacOptions ++= Seq("-encoding", "utf8"),
-  scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xlint"),
-  scalacOptions  += "-Xfuture",
-  scalacOptions  += "-Yno-adapted-args",
-  scalacOptions  += "-Ywarn-dead-code",
-  scalacOptions  += "-Ywarn-numeric-widen",
-  scalacOptions  += "-Ywarn-value-discard",
-
+  scalacOptions ++= Seq(
+    "-encoding",
+    "utf8",
+    "-deprecation",
+    "-feature",
+    "-unchecked",
+  ) ++ scalacOptions212,
   Test /              fork := false,
   Test /       logBuffered := false,
   Test / parallelExecution := true,
@@ -34,6 +42,14 @@ val dynver    = project.settings(
   libraryDependencies += "org.scalacheck"   %% "scalacheck"       % "1.15.4"                % Test,
   resolvers           += Resolver.sbtPluginRepo("releases"), // for prev artifacts, not repo1 b/c of mergly publishing
   publishSettings,
+  crossScalaVersions ++= Seq("2.13.10", "3.2.2"),
+  scalacOptions := {
+    if (scalaVersion.value.startsWith("3") || scalaVersion.value.startsWith("2.13")) {
+      scalacOptions.value.filterNot(scalacOptions212.contains(_))
+    } else {
+      scalacOptions.value
+    }
+  }
 )
 
 val sbtdynver = project.dependsOn(dynverLib).enablePlugins(SbtPlugin).settings(

--- a/dynver/src/test/scala/sbtdynver/RepoStates.scala
+++ b/dynver/src/test/scala/sbtdynver/RepoStates.scala
@@ -35,7 +35,7 @@ sealed class RepoStates(tagPrefix: String) {
     var git: Git = _
     var sha      = "undefined"
 
-    def init         = andThis(git = Git.init.setDirectory(dir).call())
+    def init         = andThis { git = Git.init.setDirectory(dir).call() }
     def dirty        = {
       // We randomize the content added otherwise we will get the same git hash for two separate commits
       // because our commits are made at almost the same time
@@ -73,8 +73,8 @@ sealed class RepoStates(tagPrefix: String) {
     def version         = dynver.        version(date).replaceAllLiterally(sha, "1234abcd")
     def sonatypeVersion = dynver.sonatypeVersion(date).replaceAllLiterally(sha, "1234abcd")
     def previousVersion = dynver.previousVersion
-    def isSnapshot      = dynver.isSnapshot
-    def isVersionStable = dynver.isVersionStable
+    def isSnapshot      = dynver.isSnapshot()
+    def isVersionStable = dynver.isVersionStable()
 
     private def doalso[A, U](x: A)(xs: U*)  = x
     private def doto[A, U](x: A)(f: A => U) = doalso(x)(f(x))


### PR DESCRIPTION
This builds on top of https://github.com/sbt/sbt-dynver/pull/244, so you'll want to address that one first before looking at this.

The main change here is that it just starts publishing the `dynver` package for 2.13 and 3.