### PR TITLE
Reproduce bug: `dynverAssertTagVersion` is `null` in onLoad

### DIFF
--- a/sbtdynver/src/sbt-test/dynver/custom-version-string/build.sbt
+++ b/sbtdynver/src/sbt-test/dynver/custom-version-string/build.sbt
@@ -1,5 +1,10 @@
 import scala.sys.process.stringToProcess
 
+Global / onLoad := (Global / onLoad).value.andThen { s =>
+  dynverAssertTagVersion.value
+  s
+}
+
 def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
   val dirtySuffix = out.dirtySuffix.dropPlus.mkString("-", "")
   if (out.isCleanAfterTag) out.ref.dropV.value + dirtySuffix // no commit info if clean after tag


### PR DESCRIPTION
Let's see if CI complains here, details follow.