### PR TITLE
Fix dynverAssertTagVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,14 +14,20 @@ lazy val scalacOptions212 = Seq(
 )
 
 inThisBuild(List(
-  scalaVersion := scala2_12,
-  organization := "com.github.sbt",
-      licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
-   description := "An sbt plugin to dynamically set your version from git",
-    developers := List(Developer("dwijnand", "Dale Wijnand", "dale wijnand gmail com", url("https://dwijnand.com"))),
-     startYear := Some(2016),
-      homepage := scmInfo.value map (_.browseUrl),
-       scmInfo := Some(ScmInfo(url("https://github.com/sbt/sbt-dynver"), "scm:git:git@github.com:sbt/sbt-dynver.git")),
+             scalaVersion := scala2_12,
+             organization := "com.github.sbt",
+                 licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
+              description := "An sbt plugin to dynamically set your version from git",
+               developers := List(Developer("dwijnand", "Dale Wijnand", "dale wijnand gmail com", url("https://dwijnand.com"))),
+                startYear := Some(2016),
+                 homepage := scmInfo.value map (_.browseUrl),
+                  scmInfo := Some(ScmInfo(url("https://github.com/sbt/sbt-dynver"), "scm:git:git@github.com:sbt/sbt-dynver.git")),
+  dynverSonatypeSnapshots := true,
+                  version := {
+                    val orig = version.value
+                    if (orig.endsWith("-SNAPSHOT")) "5.0.1-SNAPSHOT"
+                    else orig
+                  },
 
   scalacOptions ++= Seq(
     "-encoding",

--- a/sbtdynver/src/main/scala/sbtdynver/DynVerPlugin.scala
+++ b/sbtdynver/src/main/scala/sbtdynver/DynVerPlugin.scala
@@ -51,27 +51,27 @@ object DynVerPlugin extends AutoPlugin {
     dynverAssertVersion    := assertVersionImpl.value,
   )
 
-  private val getVersion = Def.setting { (date: Date, out: Option[GitDescribeOutput]) =>
+  private lazy val getVersion = Def.setting { (date: Date, out: Option[GitDescribeOutput]) =>
     out.getVersion(date, dynverSeparator.value, dynverSonatypeSnapshots.value)
   }
 
-  private val tagPrefix = Def.setting {
+  private lazy val tagPrefix = Def.setting {
     val vTagPrefix = dynverVTagPrefix.value
     val  tagPrefix = dynverTagPrefix.?.value.getOrElse(if (vTagPrefix) "v" else "")
     assert(vTagPrefix ^ tagPrefix != "v", s"Incoherence: dynverTagPrefix=$tagPrefix vs dynverVTagPrefix=$vTagPrefix")
     tagPrefix
   }
 
-  private val assertTagVersion = Def.setting {
+  private lazy val assertTagVersion = Def.setting {
     dynverGitDescribeOutput.value.assertTagVersion(version.value)
   }
 
-  private val assertVersionImpl = Def.task {
+  private lazy val assertVersionImpl = Def.task {
     val v = version.value
     val dv = dynver.value
     if (!dynverCheckVersion.value)
       sys.error(s"Version and dynver mismatch - version: $v, dynver: $dv")
   }
 
-  private val buildBase = ThisBuild / baseDirectory
+  private lazy val buildBase = ThisBuild / baseDirectory
 }

--- a/sbtdynver/src/sbt-test/dynver/assert-tag-version-ok/build.sbt
+++ b/sbtdynver/src/sbt-test/dynver/assert-tag-version-ok/build.sbt
@@ -1,0 +1,28 @@
+import scala.sys.process.stringToProcess
+import scala.sys.process.ProcessLogger
+
+TaskKey[Unit]("gitInitSetup") := {
+  implicit def log2log(log: Logger): ProcessLogger = sbtLoggerToScalaSysProcessLogger(log)
+  "git init".!!(streams.value.log)
+  "git config user.email dynver@mailinator.com".!!(streams.value.log)
+  "git config user.name dynver".!!(streams.value.log)
+}
+
+TaskKey[Unit]("gitAdd")    := {
+  implicit def log2log(log: Logger): ProcessLogger = sbtLoggerToScalaSysProcessLogger(log)
+  "git add .".!!(streams.value.log)
+}
+TaskKey[Unit]("gitCommit") := {
+  implicit def log2log(log: Logger): ProcessLogger = sbtLoggerToScalaSysProcessLogger(log)
+  "git commit -am1".!!(streams.value.log)
+}
+TaskKey[Unit]("gitTag")    := {
+  implicit def log2log(log: Logger): ProcessLogger = sbtLoggerToScalaSysProcessLogger(log)
+  "git tag -a v1.0.0 -m1.0.0".!!(streams.value.log)
+}
+def sbtLoggerToScalaSysProcessLogger(log: Logger): ProcessLogger =
+  new ProcessLogger {
+    def buffer[T](f: => T): T   = f
+    def err(s: => String): Unit = log info s
+    def out(s: => String): Unit = log error s
+  }

--- a/sbtdynver/src/sbt-test/dynver/assert-tag-version-ok/changes/build.sbt
+++ b/sbtdynver/src/sbt-test/dynver/assert-tag-version-ok/changes/build.sbt
@@ -1,0 +1,4 @@
+Global / onLoad := (Global / onLoad).value.andThen { s =>
+  dynverAssertTagVersion.value
+  s
+}

--- a/sbtdynver/src/sbt-test/dynver/assert-tag-version-ok/project/plugins.sbt
+++ b/sbtdynver/src/sbt-test/dynver/assert-tag-version-ok/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.sbt" % "sbt-dynver" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/sbtdynver/src/sbt-test/dynver/assert-tag-version-ok/test
+++ b/sbtdynver/src/sbt-test/dynver/assert-tag-version-ok/test
@@ -1,0 +1,7 @@
+> gitInitSetup
+> gitAdd
+> gitCommit
+> gitTag
+$ copy-file changes/build.sbt build.sbt
+> reload
+> about


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-dynver/issues/254
Ref https://github.com/sbt/sbt-dynver/pull/252 /cc @mkurz 

**Problem**
dynverAssertTagVersion currently throws NPE.
```
[info] [info] Loading settings from plugins.sbt ...
[info] [info] Loading project definition from /.../assert-tag-version-ok/project
[info] [info] Loading settings from build.sbt ...
[info] [error] java.lang.NullPointerException
[info] [error] 	at sbt.internal.util.Init$$anon$11.apply(Settings.scala:690)
[info] [error] 	at sbt.internal.util.Init$$anon$11.apply(Settings.scala:690)
[info] [error] 	at sbt.internal.util.AList$$anon$6.transform(AList.scala:102)
[info] [error] 	at sbt.internal.util.AList$$anon$6.transform(AList.scala:100)
[info] [error] 	at sbt.internal.util.Init$Apply.mapInputs(Settings.scala:837)
[info] [error] 	at sbt.internal.util.Init$Apply.mapReferenced(Settings.scala:832)
[info] [error] 	at sbt.internal.util.Init$Setting.mapReferenced(Settings.scala:599)
[info] [error] 	at sbt.Project$.$anonfun$transform$1(Project.scala:530)
```

**Solution**
Make things lazy to fix the bug.