### PR TITLE
Pin JGit to version 5.*

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.pin = [
+  # JGit 6.x requires Java 11, see https://www.eclipse.org/lists/cross-project-issues-dev/msg18654.html
+  { groupId = "org.eclipse.jgit", artifactId = "org.eclipse.jgit", version = "5." },
+]


### PR DESCRIPTION
JGit 6.x requires Java 11, see https://www.eclipse.org/lists/cross-project-issues-dev/msg18654.html

closes: #264 

Reference: https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md?plain=1#L93