### PR TITLE
Bump pluginCrossBuild to sbt 1.3.0, it's on Maven Central

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,6 @@ val dynverLib = LocalProject("dynver")
 val dynver    = project.settings(
   libraryDependencies += "org.eclipse.jgit"  % "org.eclipse.jgit" % "5.13.2.202306221912-r" % Test,
   libraryDependencies += "org.scalacheck"   %% "scalacheck"       % "1.17.0"                % Test,
-  resolvers           += Resolver.sbtPluginRepo("releases"), // for prev artifacts, not repo1 b/c of mergly publishing
   publishSettings,
   crossScalaVersions ++= Seq(scala2_13, scala3),
   scalacOptions := {
@@ -64,7 +63,7 @@ val sbtdynver = project.dependsOn(dynverLib).enablePlugins(SbtPlugin).settings(
   scriptedLaunchOpts   += s"-Dsbt.boot.directory=${file(sys.props("user.home")) / ".sbt" / "boot"}",
   (pluginCrossBuild / sbtVersion) := {
     scalaBinaryVersion.value match {
-      case "2.12" => "1.1.0"
+      case "2.12" => "1.3.0"
     }
   },
   publishSettings,


### PR DESCRIPTION
I started to block [repo.scala-sbt.org](http://repo.scala-sbt.org/) and [repo.typesafe.com](http://repo.typesafe.com/) in my `/etc/hosts`.

I needed to bump `pluginCrossBuild / sbtVersion` to 1.3.0 so I could fetch all dependencies from maven central.

See
- https://github.com/sbt/sbt/issues/7202

this repo could go down again.