### PR TITLE
fix assert-tag-version test

### DIFF
--- a/sbtdynver/src/sbt-test/dynver/assert-tag-version/build.sbt
+++ b/sbtdynver/src/sbt-test/dynver/assert-tag-version/build.sbt
@@ -1,4 +1,3 @@
-Global / onLoad := (Global / onLoad).value.andThen { s =>
+TaskKey[Unit]("check") := {
   dynverAssertTagVersion.value
-  s
 }

--- a/sbtdynver/src/sbt-test/dynver/assert-tag-version/test
+++ b/sbtdynver/src/sbt-test/dynver/assert-tag-version/test
@@ -1,1 +1,1 @@
--> about
+-> check


### PR DESCRIPTION
This test fail if change `pluginCrossBuild / sbtVersion` to 1.10.2 or 2.x.
 
https://github.com/sbt/sbt-dynver/blob/a3ef1b948827b22e57054316204fb3bebdf8fa94/build.sbt#L64-L66