### PR TITLE
Fix GitReg.isTag doesn't actually check for tag (#294)

### DIFF
--- a/dynver/src/main/scala/sbtdynver/DynVer.scala
+++ b/dynver/src/main/scala/sbtdynver/DynVer.scala
@@ -22,7 +22,7 @@ object GitRef extends (String => GitRef) {
   final implicit class GitRefOps(val x: GitRef) extends AnyVal { import x._
     private def prefix = x match { case x: GitTag => x.prefix case _ => DynVer.tagPrefix }
 
-    def isTag: Boolean     = value.startsWith(prefix)
+    def isTag: Boolean     = x match { case _: GitTag => true case _ => false }
     def dropPrefix: String = value.stripPrefix(prefix)
 
     def mkString(prefix: String, suffix: String): String =


### PR DESCRIPTION
It checked for the version tag prefix, which is problematic when a prefix [0-9a-f] is used (because it can match the commit SHA) or when there is no prefix at all, which was the case in the bug report. In this case, every Git ref was considered to be a tag.

The fix was rather easy (or so I think), because the version tag is checked via regex of the Git describe output. We just need to check whether the `GitRef` is a `GitTag`.