### PR TITLE
Fix SHA longer than 8 chars cannot be matched (#231)

### DIFF
--- a/dynver/src/main/scala/sbtdynver/DynVer.scala
+++ b/dynver/src/main/scala/sbtdynver/DynVer.scala
@@ -75,7 +75,7 @@ final case class GitDescribeOutput(ref: GitRef, commitSuffix: GitCommitSuffix, d
 object GitDescribeOutput extends ((GitRef, GitCommitSuffix, GitDirtySuffix) => GitDescribeOutput) {
   private val OptWs        =  """[\s\n]*""" // doesn't \s include \n? why can't this call .r?
   private val Distance     =  """\+([0-9]+)""".r
-  private val Sha          =  """([0-9a-f]{8})""".r
+  private val Sha          =  """([0-9a-f]{8,39})""".r
   private val HEAD         =  """HEAD""".r
   private val CommitSuffix = s"""(?:$Distance-$Sha)""".r
   private val TstampSuffix =  """(\+[0-9]{8}-[0-9]{4})""".r
@@ -163,7 +163,7 @@ sealed case class DynVer(wd: Option[File], separator: String, tagPrefix: String)
   def getGitDescribeOutput(d: Date): Option[GitDescribeOutput] = {
     val process = Process(s"git describe --long --tags --abbrev=8 --match $TagPattern --always --dirty=+${timestamp(d)}", wd)
     Try(process !! NoProcessLogger).toOption
-      .map(_.replaceAll("-([0-9]+)-g([0-9a-f]{8})", "+$1-$2"))
+      .map(_.replaceAll("-([0-9]+)-g([0-9a-f]{8,})", "+$1-$2"))
       .map(parser.parse)
       .flatMap { out =>
         if (out.hasNoTags())


### PR DESCRIPTION
This is kind of a lazy fix - we just allow the regex to match an SHA between 8 and 39 characters. We can't go 40, because that would break the previous version in case there isn't a tag, because the Git command outputs the whole SHA and we must not match it, because then it would be considered the "previous version".

A less lazy fix would be to change the logic that determines the previous version, but I didn't want to change more than was necessary.