### PR TITLE
fix: Fix version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,7 @@ jobs:
       shell: bash
       run: |
         sbt --client mimaReportBinaryIssues
+    - name: Cleanup
+      shell: bash
+      run: |
+        rm -rf "$HOME/.ivy2/local" || true

--- a/build.sbt
+++ b/build.sbt
@@ -24,11 +24,6 @@ inThisBuild(List(
                  homepage := scmInfo.value map (_.browseUrl),
                   scmInfo := Some(ScmInfo(url("https://github.com/sbt/sbt-dynver"), "scm:git:git@github.com:sbt/sbt-dynver.git")),
   dynverSonatypeSnapshots := true,
-                  version := {
-                    val orig = version.value
-                    if (orig.endsWith("-SNAPSHOT")) "5.0.1-SNAPSHOT"
-                    else orig
-                  },
 
   scalacOptions ++= Seq(
     "-encoding",


### PR DESCRIPTION
## Problem
Snapshot publishing is failing likely due to the overwrite.

## Solution
This lets sbt-dynver generate the SNAPSHOT version.